### PR TITLE
Move LLM demo to standalone folder

### DIFF
--- a/LLMDemoStandalone/README.md
+++ b/LLMDemoStandalone/README.md
@@ -1,0 +1,24 @@
+# LLM Demo Agent Standalone Repository
+
+This directory contains a minimal demo agent using the Hugging Face
+Transformers library. It has been moved here so it can be used as a
+separate Git repository for portfolio purposes.
+
+## Setup
+
+Create a new repository from this folder:
+
+```bash
+cd LLMDemoStandalone
+git init
+```
+
+Then install requirements and run:
+
+```bash
+pip install -r requirements.txt
+python llm_agent.py
+```
+
+The agent loads `google/flan-t5-small` and lets you chat with it
+locally. Type `quit` to exit.

--- a/LLMDemoStandalone/llm_agent.py
+++ b/LLMDemoStandalone/llm_agent.py
@@ -1,0 +1,23 @@
+import sys
+from transformers import pipeline
+
+
+def main():
+    model_name = "google/flan-t5-small"  # small model available for free
+    generator = pipeline("text2text-generation", model=model_name)
+    print("LLM agent ready. Type 'quit' to exit.")
+    while True:
+        try:
+            user_input = input("User: ")
+        except EOFError:
+            break
+        if user_input.lower() in {"quit", "exit"}:
+            print("Exiting.")
+            break
+        response = generator(user_input, max_length=128)
+        text = response[0]['generated_text']
+        print("Agent:", text)
+
+
+if __name__ == "__main__":
+    main()

--- a/LLMDemoStandalone/requirements.txt
+++ b/LLMDemoStandalone/requirements.txt
@@ -1,0 +1,2 @@
+transformers>=4.31
+torch

--- a/README.md
+++ b/README.md
@@ -7,3 +7,9 @@
 
 
 
+
+## LLM Demo Agent
+
+The lightweight LLM demo previously included in this repository has been
+moved to a standalone folder [`LLMDemoStandalone`](./LLMDemoStandalone) so
+it can be turned into its own Git repository if desired.


### PR DESCRIPTION
## Summary
- relocate the lightweight LLM demo into `LLMDemoStandalone`
- document how to create a new repository from that folder
- reference the new location in the main README

## Testing
- `pip install --user -r LLMDemoStandalone/requirements.txt`
- `python LLMDemoStandalone/llm_agent.py` *(fails: Tunnel connection failed: 403 Forbidden)*


------
https://chatgpt.com/codex/tasks/task_e_684ebd95a224832b967de3ea02f018f7